### PR TITLE
Fix repository path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "make test"
   },
-  "repository": "Level/level-iterator-stream",
+  "repository": "Level/iterator-stream",
   "dependencies": {
     "inherits": "^2.0.1",
     "level-errors": "^1.0.3",


### PR DESCRIPTION
`Level/level-iterator-stream` -> `Level/iterator-stream`

Repository currently 404ing off https://www.npmjs.com/package/level-iterator-stream